### PR TITLE
feat and example: uvw display and transformation matrix

### DIFF
--- a/bionc/vizualization/animations.py
+++ b/bionc/vizualization/animations.py
@@ -4,9 +4,9 @@ from enum import Enum
 class NaturalVectorColors(Enum):
     """Colors for the vectors."""
 
-    # light red
-    U = (255, 20, 0)
-    # light green
-    V = (0, 255, 20)
-    # light blue
-    W = (20, 0, 255)
+    # modified-magenta
+    U = (255, 0, 150)
+    # modified-yellow
+    V = (150, 255, 0)
+    # modified-cyan
+    W = (255, 255, 150)

--- a/bionc/vizualization/animations.py
+++ b/bionc/vizualization/animations.py
@@ -9,4 +9,4 @@ class NaturalVectorColors(Enum):
     # modified-yellow
     V = (150, 255, 0)
     # modified-cyan
-    W = (255, 255, 150)
+    W = (150, 255, 255)

--- a/bionc/vizualization/pyorerun_natural_vectors.py
+++ b/bionc/vizualization/pyorerun_natural_vectors.py
@@ -1,0 +1,93 @@
+import numpy as np
+
+from pyorerun.abstract.markers import rgb255_to_hex_rgba
+from pyorerun.xp_components.force_vector import Vector
+
+from ..protocols.biomechanical_model import GenericBiomechanicalModel
+from .animations import NaturalVectorColors
+
+
+class _ColoredVector(Vector):
+    """Vector with a per-instance color (the base ``Vector`` hardcodes one)."""
+
+    def __init__(self, name, num, vector_origin, vector_endpoint, color_rgb255):
+        magnitude = vector_endpoint - vector_origin
+        super().__init__(name=name, num=num, vector_origins=vector_origin, vector_magnitudes=magnitude)
+        self._color = rgb255_to_hex_rgba(np.asarray(color_rgb255))
+
+    def to_component(self, frame):
+        import rerun as rr
+
+        return rr.Arrows3D(
+            origins=self.vector_origins[:, frame],
+            vectors=self.vector_magnitude[:, frame],
+            colors=self._color,
+        )
+
+    def to_chunk(self, **kwargs):
+        import rerun as rr
+
+        return {
+            self.name: [
+                *rr.Arrows3D.columns(
+                    origins=self.vector_origins.T.tolist(),
+                    vectors=self.vector_magnitude.T.tolist(),
+                    colors=[self._color for _ in range(self.nb_frames)],
+                )
+            ]
+        }
+
+
+def add_natural_vectors(
+    phase_rerun,
+    model: GenericBiomechanicalModel,
+    Q: np.ndarray,
+    scale_u: float = 0.2,
+    scale_v: float = 1.0,
+    scale_w: float = 0.2,
+) -> None:
+    """
+    Add the u, v, w natural-coordinate vectors of every segment to a pyorerun phase.
+
+    Vectors are anchored at the proximal point ``rp`` and colored according to
+    ``NaturalVectorColors`` (red / green / blue for u / v / w).
+
+    Parameters
+    ----------
+    phase_rerun
+        A ``pyorerun.PhaseRerun`` instance already configured for the trajectory.
+    model
+        The biomechanical model providing segment names.
+    Q
+        Natural coordinates trajectory of shape ``(nb_Q, nb_frames)``.
+    scale_u, scale_v, scale_w
+        Multiplicative scale factors applied to each natural vector for display.
+        ``v`` is the segment vector ``rd - rp`` and is unscaled by default
+        (``scale_v=1.0``) so it spans the full segment.
+    """
+    Q = np.asarray(Q, dtype=float)
+    if Q.ndim != 2 or Q.shape[0] != 12 * model.nb_segments:
+        raise ValueError(
+            f"Q must have shape (12*nb_segments, nb_frames); got {Q.shape} for nb_segments={model.nb_segments}."
+        )
+
+    for i, seg_name in enumerate(model.segment_names):
+        u = Q[12 * i + 0 : 12 * i + 3, :]
+        rp = Q[12 * i + 3 : 12 * i + 6, :]
+        rd = Q[12 * i + 6 : 12 * i + 9, :]
+        w = Q[12 * i + 9 : 12 * i + 12, :]
+
+        for axis_name, endpoint, color in (
+            (f"{seg_name}_u", rp + scale_u * u, NaturalVectorColors.U.value),
+            (f"{seg_name}_v", rp + scale_v * (rd - rp), NaturalVectorColors.V.value),
+            (f"{seg_name}_w", rp + scale_w * w, NaturalVectorColors.W.value),
+        ):
+            phase_rerun.xp_data.add_data(
+                _ColoredVector(
+                    name=f"{phase_rerun.name}/{axis_name}",
+                    num=i,
+                    vector_origin=rp,
+                    vector_endpoint=endpoint,
+                    color_rgb255=color,
+                )
+            )

--- a/examples/model_creation/right_side_lower_limb.py
+++ b/examples/model_creation/right_side_lower_limb.py
@@ -384,6 +384,7 @@ def main():
     Qxp = model.Q_from_markers(markers_xp[:, :, 0:2])
 
     from bionc.vizualization.pyorerun_interface import BioncModelNoMesh
+    from bionc.vizualization.pyorerun_natural_vectors import add_natural_vectors
     from pyorerun import PhaseRerun, PyoMarkers
 
     # display the experimental markers in white and the model markers in blue
@@ -393,6 +394,7 @@ def main():
 
     pyomarker = PyoMarkers.from_c3d(filename)
     prr.add_animated_model(model_interface, Qxp, pyomarker)
+    add_natural_vectors(prr, model, np.asarray(Qxp), scale_u=0.1, scale_v=1.0, scale_w=0.1)
     prr.rerun()
 
     # remove the c3d file

--- a/examples/muscles/double_pendulum_with_muscles.py
+++ b/examples/muscles/double_pendulum_with_muscles.py
@@ -180,9 +180,11 @@ def animate(nb_frames: int = 120):
 
     from pyorerun import PhaseRerun
     from bionc.vizualization.pyorerun_interface import BioncModelNoMesh
+    from bionc.vizualization.pyorerun_natural_vectors import add_natural_vectors
 
     prr = PhaseRerun(t_span=t)
     prr.add_animated_model(BioncModelNoMesh(model), Q_traj)
+    add_natural_vectors(prr, model, Q_traj, scale_u=0.25, scale_v=1.0, scale_w=0.25)
     prr.rerun()
 
 

--- a/examples/transformation_matrix/compare_transformation_matrices.py
+++ b/examples/transformation_matrix/compare_transformation_matrices.py
@@ -1,0 +1,126 @@
+"""
+Side-by-side, animated comparison of every available ``TransformationMatrixType``.
+
+Each implemented type gets its own copy of the same non-orthogonal natural
+frame (u, v, w drawn in ``NaturalVectorColors``), arranged in a row along the
+global x axis. The orthogonal segment frame derived from that type is drawn
+at the same anchor with **always-RGB** axes (x = red, y = green, z = blue),
+so the user can read each tile independently and see how the orthogonal frame
+re-aligns when the natural angles (alpha, beta, gamma) wobble in time via a
+cosine sweep.
+"""
+
+import numpy as np
+
+from bionc import TransformationMatrixType
+from bionc.bionc_numpy.transformation_matrix import (
+    TRANSFORMATION_MAP,
+    compute_transformation_matrix,
+)
+from bionc.vizualization.animations import NaturalVectorColors
+from bionc.vizualization.pyorerun_natural_vectors import _ColoredVector
+
+
+RGB_RED = (255, 0, 0)
+RGB_GREEN = (0, 255, 0)
+RGB_BLUE = (0, 0, 255)
+
+
+def _implemented_types() -> list[TransformationMatrixType]:
+    """Return the TransformationMatrixType values whose B(length, alpha, beta, gamma) is implemented."""
+    available = []
+    for t in TransformationMatrixType:
+        try:
+            TRANSFORMATION_MAP[t](1.0, np.pi / 2, np.pi / 2, np.pi / 2)
+        except NotImplementedError:
+            continue
+        available.append(t)
+    return available
+
+
+def _angle_sweep(nb_frames: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Cosine-driven (alpha, beta, gamma) trajectory; returns radians + the time axis."""
+    t = np.linspace(0.0, 1.0, nb_frames)
+    cos = np.cos(2.0 * np.pi * t)
+    alpha = np.deg2rad(70.0 + 10.0 * cos)
+    beta = np.deg2rad(80.0 + 10.0 * np.cos(2.0 * np.pi * t + np.pi / 3))
+    gamma = np.deg2rad(60.0 + 10.0 * np.cos(2.0 * np.pi * t + 2.0 * np.pi / 3))
+    return t, alpha, beta, gamma
+
+
+def _natural_and_orthogonal_axes(
+    types: list[TransformationMatrixType],
+    alpha: np.ndarray,
+    beta: np.ndarray,
+    gamma: np.ndarray,
+) -> tuple[np.ndarray, dict[TransformationMatrixType, np.ndarray]]:
+    """
+    Return:
+      natural -- (3, 3, nb_frames) with columns [u, v_basis, w] from B_Buv
+      ortho   -- { type: (3, 3, nb_frames) rotation matrix expressing the type's
+                  orthogonal axes (e_x, e_y, e_z as columns) in our chosen global,
+                  which coincides with the Buv segment-Cartesian frame. }
+    """
+    nb_frames = alpha.size
+    natural = np.zeros((3, 3, nb_frames))
+    ortho = {t: np.zeros((3, 3, nb_frames)) for t in types}
+
+    for k in range(nb_frames):
+        B_ref = compute_transformation_matrix(TransformationMatrixType.Buv, 1.0, alpha[k], beta[k], gamma[k])
+        natural[:, :, k] = B_ref
+        for t in types:
+            B_t = compute_transformation_matrix(t, 1.0, alpha[k], beta[k], gamma[k])
+            # Express the type's orthogonal axes in our reference (Buv) global frame.
+            ortho[t][:, :, k] = B_ref @ np.linalg.inv(B_t)
+    return natural, ortho
+
+
+def _add_arrow(prr, name: str, num: int, origin: np.ndarray, endpoint: np.ndarray, color_rgb255: tuple) -> None:
+    prr.xp_data.add_data(
+        _ColoredVector(
+            name=f"{prr.name}/{name}",
+            num=num,
+            vector_origin=origin,
+            vector_endpoint=endpoint,
+            color_rgb255=color_rgb255,
+        )
+    )
+
+
+def main(nb_frames: int = 90, tile_spacing: float = 2.5, ortho_scale: float = 0.6):
+    types = _implemented_types()
+    t, alpha, beta, gamma = _angle_sweep(nb_frames)
+    natural, ortho = _natural_and_orthogonal_axes(types, alpha, beta, gamma)
+
+    nat_u = natural[:, 0, :]
+    nat_v = natural[:, 1, :]
+    nat_w = natural[:, 2, :]
+
+    from pyorerun import PhaseRerun
+
+    prr = PhaseRerun(t_span=t)
+
+    for i, type_enum in enumerate(types):
+        rp = np.tile(np.array([[i * tile_spacing], [0.0], [0.0]]), (1, nb_frames))
+
+        _add_arrow(prr, f"{type_enum.name}/u", i, rp, rp + nat_u, NaturalVectorColors.U.value)
+        _add_arrow(prr, f"{type_enum.name}/v", i, rp, rp + nat_v, NaturalVectorColors.V.value)
+        _add_arrow(prr, f"{type_enum.name}/w", i, rp, rp + nat_w, NaturalVectorColors.W.value)
+
+        rot = ortho[type_enum]
+        _add_arrow(prr, f"{type_enum.name}/x", i, rp, rp + ortho_scale * rot[:, 0, :], RGB_RED)
+        _add_arrow(prr, f"{type_enum.name}/y", i, rp, rp + ortho_scale * rot[:, 1, :], RGB_GREEN)
+        _add_arrow(prr, f"{type_enum.name}/z", i, rp, rp + ortho_scale * rot[:, 2, :], RGB_BLUE)
+
+    print("Tiles laid out along x; each tile shares the same natural u/v/w but shows")
+    print("a different orthogonal frame derived from its TransformationMatrixType.")
+    print("Natural axes use NaturalVectorColors; orthogonal axes are always RGB.")
+    print("Available types (left to right):", ", ".join(t.name for t in types))
+    skipped = [t.name for t in TransformationMatrixType if t not in types]
+    if skipped:
+        print("Skipped (not implemented):", ", ".join(skipped))
+    prr.rerun()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/transformation_matrix/compare_transformation_matrices.py
+++ b/examples/transformation_matrix/compare_transformation_matrices.py
@@ -20,7 +20,6 @@ from bionc.bionc_numpy.transformation_matrix import (
 from bionc.vizualization.animations import NaturalVectorColors
 from bionc.vizualization.pyorerun_natural_vectors import _ColoredVector
 
-
 RGB_RED = (255, 0, 0)
 RGB_GREEN = (0, 255, 0)
 RGB_BLUE = (0, 0, 255)

--- a/tests/test_compare_transformation_matrices.py
+++ b/tests/test_compare_transformation_matrices.py
@@ -103,7 +103,7 @@ def test_main_registers_one_arrow_per_axis_per_tile():
     # Origins of the first frame land at (i*spacing, 0, 0) for tile i.
     origins_per_tile = {}
     for arrow in captured["arrows"]:
-        type_label = arrow.name.split("/")[-2]  # ".../<TYPE>/<axis>/force_vector_<num>"
+        type_label = arrow.name.split("/")[-3]  # ".../<TYPE>/<axis>/force_vector_<num>"
         origins_per_tile.setdefault(type_label, set()).add(tuple(arrow.vector_origins[:, 0]))
     for i, type_enum in enumerate(module._implemented_types()):
         # All six arrows of a tile share the same origin.

--- a/tests/test_compare_transformation_matrices.py
+++ b/tests/test_compare_transformation_matrices.py
@@ -9,9 +9,7 @@ from bionc import TransformationMatrixType
 
 def _load_module():
     bionc = TestUtils.bionc_folder()
-    return TestUtils.load_module(
-        bionc + "/examples/transformation_matrix/compare_transformation_matrices.py"
-    )
+    return TestUtils.load_module(bionc + "/examples/transformation_matrix/compare_transformation_matrices.py")
 
 
 def test_implemented_types_excludes_unimplemented_ones():
@@ -55,8 +53,12 @@ def test_buv_orthogonal_frame_is_identity_per_frame():
 
 @pytest.mark.parametrize(
     "type_enum",
-    [TransformationMatrixType.Buv, TransformationMatrixType.Bvu,
-     TransformationMatrixType.Bwu, TransformationMatrixType.Buw],
+    [
+        TransformationMatrixType.Buv,
+        TransformationMatrixType.Bvu,
+        TransformationMatrixType.Bwu,
+        TransformationMatrixType.Buw,
+    ],
 )
 def test_orthogonal_axes_have_unit_norm(type_enum):
     """For every implemented type and every frame, the three columns of the

--- a/tests/test_compare_transformation_matrices.py
+++ b/tests/test_compare_transformation_matrices.py
@@ -1,0 +1,139 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("pyorerun")
+
+from .utils import TestUtils
+from bionc import TransformationMatrixType
+
+
+def _load_module():
+    bionc = TestUtils.bionc_folder()
+    return TestUtils.load_module(
+        bionc + "/examples/transformation_matrix/compare_transformation_matrices.py"
+    )
+
+
+def test_implemented_types_excludes_unimplemented_ones():
+    module = _load_module()
+    types = module._implemented_types()
+    assert TransformationMatrixType.Buv in types
+    assert TransformationMatrixType.Bvu in types
+    assert TransformationMatrixType.Bwu in types
+    assert TransformationMatrixType.Buw in types
+    assert TransformationMatrixType.Bvw not in types
+    assert TransformationMatrixType.Bwv not in types
+
+
+def test_angle_sweep_uses_cosine():
+    module = _load_module()
+    nb_frames = 60
+    t, alpha, beta, gamma = module._angle_sweep(nb_frames)
+    assert t.shape == (nb_frames,)
+    assert alpha.shape == (nb_frames,)
+    # Cosine-periodic: first frame value ~ last frame value.
+    np.testing.assert_almost_equal(alpha[0], alpha[-1], decimal=10)
+    np.testing.assert_almost_equal(beta[0], beta[-1], decimal=10)
+    np.testing.assert_almost_equal(gamma[0], gamma[-1], decimal=10)
+    # Values vary, so the sweep is not constant.
+    assert alpha.std() > 0
+    assert beta.std() > 0
+    assert gamma.std() > 0
+
+
+def test_buv_orthogonal_frame_is_identity_per_frame():
+    """With our reference choice (global = Buv segment-Cartesian), the Buv tile's
+    orthogonal axes are always the global axes."""
+    module = _load_module()
+    types = module._implemented_types()
+    _, alpha, beta, gamma = module._angle_sweep(40)
+    _, ortho = module._natural_and_orthogonal_axes(types, alpha, beta, gamma)
+    rot_buv = ortho[TransformationMatrixType.Buv]
+    for k in range(rot_buv.shape[2]):
+        np.testing.assert_almost_equal(rot_buv[:, :, k], np.eye(3), decimal=10)
+
+
+@pytest.mark.parametrize(
+    "type_enum",
+    [TransformationMatrixType.Buv, TransformationMatrixType.Bvu,
+     TransformationMatrixType.Bwu, TransformationMatrixType.Buw],
+)
+def test_orthogonal_axes_have_unit_norm(type_enum):
+    """For every implemented type and every frame, the three columns of the
+    orthogonal rotation matrix are (approximately) unit vectors."""
+    module = _load_module()
+    types = module._implemented_types()
+    _, alpha, beta, gamma = module._angle_sweep(20)
+    _, ortho = module._natural_and_orthogonal_axes(types, alpha, beta, gamma)
+    rot = ortho[type_enum]
+    for k in range(rot.shape[2]):
+        for col in range(3):
+            np.testing.assert_almost_equal(np.linalg.norm(rot[:, col, k]), 1.0, decimal=2)
+
+
+def test_main_registers_one_arrow_per_axis_per_tile():
+    """Six arrows per tile: u, v, w (natural) + x, y, z (orthogonal, always RGB)."""
+    import pyorerun
+
+    module = _load_module()
+    captured = {}
+
+    def fake_rerun(self):
+        captured["names"] = list(self.xp_data.component_names)
+        captured["arrows"] = list(self.xp_data.xp_data)
+
+    monkey = pyorerun.PhaseRerun.rerun
+    pyorerun.PhaseRerun.rerun = fake_rerun
+    try:
+        module.main(nb_frames=8)
+    finally:
+        pyorerun.PhaseRerun.rerun = monkey
+
+    nb_types = len(module._implemented_types())
+    assert len(captured["names"]) == 6 * nb_types
+
+    # Tiles are spaced along x.
+    spacing = 2.5
+    for i, type_enum in enumerate(module._implemented_types()):
+        for axis in ("u", "v", "w", "x", "y", "z"):
+            assert any(f"{type_enum.name}/{axis}" in n for n in captured["names"])
+
+    # Origins of the first frame land at (i*spacing, 0, 0) for tile i.
+    origins_per_tile = {}
+    for arrow in captured["arrows"]:
+        type_label = arrow.name.split("/")[-2]  # ".../<TYPE>/<axis>/force_vector_<num>"
+        origins_per_tile.setdefault(type_label, set()).add(tuple(arrow.vector_origins[:, 0]))
+    for i, type_enum in enumerate(module._implemented_types()):
+        # All six arrows of a tile share the same origin.
+        assert origins_per_tile[type_enum.name] == {(i * spacing, 0.0, 0.0)}
+
+
+def test_orthogonal_axes_use_pure_rgb():
+    """Orthogonal axes (x, y, z) must be drawn in pure red, green, blue."""
+    from pyorerun.abstract.markers import rgb255_to_hex_rgba
+    import pyorerun
+
+    module = _load_module()
+    captured = {}
+
+    def fake_rerun(self):
+        captured["arrows"] = list(self.xp_data.xp_data)
+
+    monkey = pyorerun.PhaseRerun.rerun
+    pyorerun.PhaseRerun.rerun = fake_rerun
+    try:
+        module.main(nb_frames=4)
+    finally:
+        pyorerun.PhaseRerun.rerun = monkey
+
+    expected = {
+        "x": rgb255_to_hex_rgba(np.array([255, 0, 0])),
+        "y": rgb255_to_hex_rgba(np.array([0, 255, 0])),
+        "z": rgb255_to_hex_rgba(np.array([0, 0, 255])),
+    }
+    for arrow in captured["arrows"]:
+        # Names look like ".../<TYPE>/<axis>/force_vector_<num>"
+        parts = arrow.name.split("/")
+        axis = parts[-2]
+        if axis in expected:
+            assert arrow._color == expected[axis], f"{arrow.name}: {arrow._color} != {expected[axis]}"

--- a/tests/test_pyorerun_natural_vectors.py
+++ b/tests/test_pyorerun_natural_vectors.py
@@ -1,0 +1,126 @@
+import numpy as np
+import pytest
+
+pyorerun = pytest.importorskip("pyorerun")
+
+from bionc import (
+    BiomechanicalModel,
+    CartesianAxis,
+    JointType,
+    NaturalAxis,
+    NaturalCoordinates,
+    NaturalSegment,
+    SegmentNaturalCoordinates,
+    TransformationMatrixType,
+)
+from bionc.vizualization.animations import NaturalVectorColors
+from bionc.vizualization.pyorerun_natural_vectors import add_natural_vectors
+
+
+def _hanging_pendulum_Q(nb_frames: int = 3) -> tuple[BiomechanicalModel, np.ndarray]:
+    model = BiomechanicalModel()
+    model["pendulum"] = NaturalSegment.with_cartesian_inertial_parameters(
+        name="pendulum",
+        alpha=np.pi / 2,
+        beta=np.pi / 2,
+        gamma=np.pi / 2,
+        length=1.0,
+        mass=1.0,
+        center_of_mass=np.array([0.0, -0.5, 0.0]),
+        inertia=np.diag([0.05, 0.05, 0.05]),
+        inertial_transformation_matrix=TransformationMatrixType.Buv,
+    )
+    model._add_joint(
+        dict(
+            name="hinge",
+            joint_type=JointType.GROUND_REVOLUTE,
+            parent="GROUND",
+            child="pendulum",
+            parent_axis=[CartesianAxis.X, CartesianAxis.X],
+            child_axis=[NaturalAxis.V, NaturalAxis.W],
+            theta=[np.pi / 2, np.pi / 2],
+        )
+    )
+    Qi = SegmentNaturalCoordinates.from_components(u=[1, 0, 0], rp=[0, 0, 0], rd=[0, -1, 0], w=[0, 0, 1])
+    Q = np.asarray(NaturalCoordinates(Qi)).reshape(-1, 1)
+    Q_traj = np.repeat(Q, nb_frames, axis=1)
+    return model, Q_traj
+
+
+def test_add_natural_vectors_registers_three_per_segment():
+    model, Q = _hanging_pendulum_Q(nb_frames=4)
+    prr = pyorerun.PhaseRerun(t_span=np.linspace(0.0, 1.0, Q.shape[1]))
+    add_natural_vectors(prr, model, Q)
+
+    names = prr.xp_data.component_names
+    assert len(names) == 3 * model.nb_segments
+    for axis in ("pendulum_u", "pendulum_v", "pendulum_w"):
+        assert any(axis in n for n in names), names
+
+
+def test_add_natural_vectors_origins_and_endpoints():
+    """Origins must equal rp; endpoints follow rp + scale * axis."""
+    model, Q = _hanging_pendulum_Q(nb_frames=2)
+    scale = dict(scale_u=0.3, scale_v=0.7, scale_w=0.4)
+    prr = pyorerun.PhaseRerun(t_span=np.linspace(0.0, 1.0, Q.shape[1]))
+    add_natural_vectors(prr, model, Q, **scale)
+
+    rp = Q[3:6, :]
+    u = Q[0:3, :]
+    rd = Q[6:9, :]
+    w = Q[9:12, :]
+    expected_magnitudes = {
+        "pendulum_u": scale["scale_u"] * u,
+        "pendulum_v": scale["scale_v"] * (rd - rp),
+        "pendulum_w": scale["scale_w"] * w,
+    }
+
+    by_axis = {}
+    for vec in prr.xp_data.xp_data:
+        for axis_name in expected_magnitudes:
+            if axis_name in vec.name:
+                by_axis[axis_name] = vec
+                break
+    assert set(by_axis) == set(expected_magnitudes)
+
+    for axis_name, vec in by_axis.items():
+        np.testing.assert_allclose(vec.vector_origins, rp)
+        np.testing.assert_allclose(vec.vector_magnitude, expected_magnitudes[axis_name])
+
+
+def test_add_natural_vectors_uses_natural_vector_colors():
+    """u/v/w arrows must carry the colors defined in NaturalVectorColors."""
+    from pyorerun.abstract.markers import rgb255_to_hex_rgba
+
+    model, Q = _hanging_pendulum_Q()
+    prr = pyorerun.PhaseRerun(t_span=np.linspace(0.0, 1.0, Q.shape[1]))
+    add_natural_vectors(prr, model, Q)
+
+    expected = {
+        "pendulum_u": rgb255_to_hex_rgba(np.asarray(NaturalVectorColors.U.value)),
+        "pendulum_v": rgb255_to_hex_rgba(np.asarray(NaturalVectorColors.V.value)),
+        "pendulum_w": rgb255_to_hex_rgba(np.asarray(NaturalVectorColors.W.value)),
+    }
+    for vec in prr.xp_data.xp_data:
+        for axis_name, color in expected.items():
+            if axis_name in vec.name:
+                assert vec._color == color, f"{axis_name} got {vec._color} expected {color}"
+
+
+def test_add_natural_vectors_rejects_wrong_Q_shape():
+    model, _ = _hanging_pendulum_Q()
+    prr = pyorerun.PhaseRerun(t_span=np.array([0.0, 1.0]))
+
+    with pytest.raises(ValueError, match="must have shape"):
+        add_natural_vectors(prr, model, np.zeros((11, 2)))
+    with pytest.raises(ValueError, match="must have shape"):
+        add_natural_vectors(prr, model, np.zeros(12))
+
+
+def test_add_natural_vectors_to_chunk_runs():
+    """to_chunk() should serialize without raising for our colored vectors."""
+    model, Q = _hanging_pendulum_Q(nb_frames=5)
+    prr = pyorerun.PhaseRerun(t_span=np.linspace(0.0, 1.0, Q.shape[1]))
+    add_natural_vectors(prr, model, Q)
+    chunks = prr.xp_data.to_chunk()
+    assert len(chunks) == 3 * model.nb_segments


### PR DESCRIPTION
Answer one item of #147 

- displayable uvw in animations with pyorerun
- new example displaying all the transformations from uvw to xyz


Magenta U, greenish V, yellowish W
RGB XYZ
From left to right: Buv, Buw, Bvu, Bwu

[Capture vidéo du 2026-05-06 11-22-07.webm](https://github.com/user-attachments/assets/296daea6-93f4-4896-b9c8-b2b493482fde)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Ipuch/bioNC/164)
<!-- Reviewable:end -->
